### PR TITLE
fix: 主题设置重启后不失效，切换主题时同步写入 localStorage

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -48,7 +48,9 @@ const SettingsCtx = createContext<{ cache: SettingsCache; updateCache: (patch: P
 });
 
 const App: React.FC = () => {
-  const [theme, setTheme] = useState<'light' | 'dark'>('light');
+  const [theme, setTheme] = useState<'light' | 'dark'>(
+    () => (localStorage.getItem('theme') as 'light' | 'dark') || 'light'
+  );
   const [settingsCache, setSettingsCache] = useState<SettingsCache>(defaultCache);
 
   // Load settings once on app startup
@@ -104,7 +106,11 @@ const App: React.FC = () => {
     return () => window.removeEventListener('contextmenu', handleContextMenu);
   }, []);
 
-  const toggleTheme = () => setTheme(prev => prev === 'light' ? 'dark' : 'light');
+  const toggleTheme = () => setTheme(prev => {
+    const next = prev === 'light' ? 'dark' : 'light';
+    localStorage.setItem('theme', next);
+    return next;
+  });
   const routeFallback = (
     <div className="h-full min-h-[240px] flex items-center justify-center text-sm text-text-secondary">
       正在加载页面...


### PR DESCRIPTION
## Summary修复主题设置重启后失效的问题。

## Changes

**frontend/src/App.tsx**

- `useState` 初始值从硬编码 `'light'` 改为从 `localStorage` 懒读取
- `toggleTheme` 切换时同步写入 `localStorage`

关闭程序重启后，主题状态与上次保持一致，不再重置为浅色。
